### PR TITLE
fix: sidebar items view

### DIFF
--- a/components/layout/dashboard-sidebar.tsx
+++ b/components/layout/dashboard-sidebar.tsx
@@ -174,11 +174,11 @@ export function DashboardSidebar({ links, user, schools }: DashboardSidebarProps
               ))}
             </nav>
 
-            {isSidebarExpanded && (
+            {/* {isSidebarExpanded && (
               <div className="mt-auto p-4">
                 <UpgradeCard />
               </div>
-            )}
+            )} */}
           </div>
         </aside>
       </ScrollArea>
@@ -230,9 +230,9 @@ export function MobileSheetSidebar({ links, user, schools }: DashboardSidebarPro
                   </section>
                 ))}
 
-                <div className="mt-auto">
+                {/* <div className="mt-auto">
                   <UpgradeCard />
-                </div>
+                </div> */}
               </nav>
             </div>
           </ScrollArea>

--- a/config/dashboard.ts
+++ b/config/dashboard.ts
@@ -16,34 +16,54 @@ export const sidebarLinks: SidebarNavItem[] = [
         title: "Financials",
         authorizeOnly: ["ADMIN", "ACCOUNTANT"],
       },
+    
       {
-        href: "/admin/calendar",
-        icon: "calendar",
-        title: "Schedules",
+        href: "/admin/attendance",
+        title: "Peoples",
         authorizeOnly: ["ADMIN", "ACCOUNTANT", "TEACHER"],
-      },
-      {
-        href: "/admin/staff",
-        icon: "briefcase",
-        title: "Staff",
-        authorizeOnly: ["ADMIN", "ACCOUNTANT"],
-      },
-      {
-        href: "/admin/parents",
-        icon: "users",
-        title: "Parents",
-        authorizeOnly: ["ADMIN", "ACCOUNTANT", "TEACHER"],
+        children: [
+          {
+            href: "/admin/staff",
+            icon: "briefcase",
+            title: "Staff",
+            authorizeOnly: ["ADMIN", "ACCOUNTANT"],
+          },
+          {
+            href: "/admin/parents",
+            icon: "users",
+            title: "Parents",
+            authorizeOnly: ["ADMIN", "ACCOUNTANT", "TEACHER"],
+          },
+        ]
       },
       {
         href: "/admin/class",
         icon: "book",
-        title: "Classes",
+        title: "Academic",
         authorizeOnly: ["ADMIN", "ACCOUNTANT", "TEACHER"],
         children: [
+          {
+            href: "/admin/calendar",
+            icon: "calendar",
+            title: "Schedules",
+            authorizeOnly: ["ADMIN", "ACCOUNTANT", "TEACHER"],
+          },
           {
             href: "/admin/students",
             icon: "users",
             title: "Students",
+            authorizeOnly: ["ADMIN", "ACCOUNTANT", "TEACHER"],
+          },
+          {
+            href: "/admin/classes",
+            icon: "book",
+            title: "Classes",
+            authorizeOnly: ["ADMIN", "ACCOUNTANT", "TEACHER"],
+          },
+          {
+            href: "/admin/subjects",
+            icon: "book",
+            title: "Subjects",
             authorizeOnly: ["ADMIN", "ACCOUNTANT", "TEACHER"],
           },
           {
@@ -56,6 +76,12 @@ export const sidebarLinks: SidebarNavItem[] = [
             href: "/admin/attendance",
             icon: "clipboard",
             title: "Attendance",
+            authorizeOnly: ["ADMIN", "ACCOUNTANT", "TEACHER"],
+          },
+          {
+            href: "/admin/exams",
+            icon: "clipboard",
+            title: "Exams",
             authorizeOnly: ["ADMIN", "ACCOUNTANT", "TEACHER"],
           },
         ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new sidebar item titled "Peoples" with links for "Staff" and "Parents."
	- Renamed the "Classes" section to "Academic" and added child links for "Classes," "Subjects," and "Exams."
  
- **Bug Fixes**
	- Disabled the display of the `UpgradeCard` component in both the Dashboard and Mobile sidebar implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->